### PR TITLE
Add MIT license and license information to README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 DataFund
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -330,3 +330,21 @@ Get the chequebook address and balance information of the connected Bee node.
   - `availableBalance`: Funds available for creating new postage stamps (in wei)
   - `totalBalance`: Total funds in the chequebook (in wei)
 - **Note**: Only available when connected to local Bee nodes, not public gateways
+
+## License
+
+This project is licensed under the [MIT License](LICENSE) - see the LICENSE file for details.
+
+### License Summary
+- ✅ **Commercial use** - Use in commercial applications
+- ✅ **Distribution** - Distribute copies or substantial portions
+- ✅ **Modification** - Modify and create derivative works
+- ✅ **Private use** - Use privately without restrictions
+- ⚠️ **Include license** - Include MIT license and copyright notice
+- ❌ **No liability** - No warranty or liability from authors
+
+The MIT License encourages adoption while maintaining attribution, making it ideal for:
+- Research and academic projects
+- Commercial integrations
+- Open-source ecosystem growth
+- Ethereum/Web3 community standards


### PR DESCRIPTION
- Add LICENSE file with MIT license and DataFund copyright
- Update README.md with license section including summary of permissions
- MIT license chosen for maximum compatibility with Web3/Ethereum ecosystem
- Enables commercial use, modification, and distribution with attribution